### PR TITLE
openhpid/safhpi.c: fix function saHpiSensorThresholdsSet

### DIFF
--- a/openhpid/safhpi.c
+++ b/openhpid/safhpi.c
@@ -1933,7 +1933,7 @@ SaErrorT SAHPI_API saHpiSensorThresholdsSet (
         oh_release_domain(d); /* Unlock domain */
 
         OH_CALL_ABI(h, set_sensor_thresholds, SA_ERR_HPI_INVALID_CMD, rv,
-                    ResourceId, SensorNum, SensorThresholds);
+                    ResourceId, SensorNum, &tmp);
         oh_release_handler(h);
 
         return rv;


### PR DESCRIPTION
In COPY_TH the SensorThresholds->TH will be copied to tmp.TH only if
TH.IsSupported == SAHPI_TRUE. So we should pass &tmp but not
SensorThresholds as the argument to OH_CALL_ABI. Otherwise the TH will
be set even if TH.IsSupported == SAHPI_FALSE.

Signed-off-by: yanjun.zhu <yanjun.zhu@windriver.com>
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>