### PR TITLE
C type error in the ov_rest plugin

### DIFF
--- a/plugins/ov_rest/ov_rest_re_discover.c
+++ b/plugins/ov_rest/ov_rest_re_discover.c
@@ -706,7 +706,7 @@ SaErrorT remove_composer(struct oh_handler_state *handler,
 		byte bayNumber)
 {
 
-        SaErrorT rv = NULL;
+        SaErrorT rv = 0;
         SaHpiResourceIdT resource_id = 0;
         struct oh_event event = {0};
 	struct ovRestHotswapState *hotswap_state = NULL;


### PR DESCRIPTION
NULL can have a pointer type, and converting pointers to integers without a cast is not valid C.  Compilers are beginning to treat this an error, leading to a build failure.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
